### PR TITLE
Fix CSS styles for Shadow DOM

### DIFF
--- a/vaadin-upload-file.html
+++ b/vaadin-upload-file.html
@@ -142,7 +142,7 @@ Custom property | Description | Default
         @apply(--vaadin-upload-file-progress-complete);
       }
 
-      :host.fade-out {
+      :host(.fade-out) {
         animation-name: fade-out;
         animation-duration: 1s;
         @apply(--vaadin-upload-file-canceled);

--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -70,14 +70,14 @@ Custom property | Description | Default
         overflow: hidden;
       }
 
-      :host:not([nodrop]) {
+      :host(:not([nodrop])) {
         border: 1px dashed;
         border-color: var(--divider-color,  #666);
         border-radius: 3px;
         padding: 16px;
       }
 
-      :host[dragover-valid] {
+      :host([dragover-valid]) {
         border-color: var(--primary-color, #00B4F0);
       }
 
@@ -91,7 +91,7 @@ Custom property | Description | Default
         display: none;
         z-index: 10;
       }
-      :host[dragover]::before {
+      :host([dragover])::before {
         display: block;
       }
 
@@ -108,8 +108,8 @@ Custom property | Description | Default
         @apply(--vaadin-upload-drop-label);
       }
 
-      :host[dragover-valid] #dropLabel,
-      :host[dragover-valid] ::content .drop-label {
+      :host([dragover-valid]) #dropLabel,
+      :host([dragover-valid]) ::content .drop-label {
         color: var(--primary-color, #00B4F0);
         @apply(--vaadin-upload-drop-label-dragover);
       }
@@ -133,7 +133,7 @@ Custom property | Description | Default
         @apply(--vaadin-upload-buttons);
       }
 
-      :host[nodrop] #buttons {
+      :host([nodrop]) #buttons {
         @apply(--layout-end-justified);
         @apply(--vaadin-upload-buttons-nodrop);
       }
@@ -152,7 +152,7 @@ Custom property | Description | Default
         @apply(--vaadin-upload-button-add);
       }
 
-      :host[nodrop] #addFiles {
+      :host([nodrop]) #addFiles {
         margin-right: auto;
         @apply(--vaadin-upload-button-add-nodrop);
       }


### PR DESCRIPTION
Some CSS styles matching :host with some additional conditions (like
:host.class, :host[attr]) doesn't work for Shadow DOM.

This change makes such CSS styles to use :host() funciton pseudo-class syntax
(i.e., :host(.class), :host([attr])). It makes them working for Shadow DOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/41)
<!-- Reviewable:end -->
