### PR TITLE
Fix for remove button's ripple cut on the right when nodrop is true

### DIFF
--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -67,13 +67,13 @@ Custom property | Description | Default
         display: block;
         position: relative;
         text-align: left;
-        overflow: hidden;
       }
 
       :host(:not([nodrop])) {
         border: 1px dashed;
         border-color: var(--divider-color,  #666);
         border-radius: 3px;
+        overflow: hidden;
         padding: 16px;
       }
 


### PR DESCRIPTION
Issue: when nodrop is true (on touch devices), the file remove button's ripple effect gets cut on the right. This is caused by the default `overflow: hidden` style on the hosting element of the `<vaadin-upload>`.

The `overflow: hidden` was introduced to limit the upload's drag ripple effect. So when nodrop is true, it's not necessary.

This change removes `overflow: hidden` style when nodrop is true, so it doesn't cut the right edge of the file remove button.

When nodrop is false (as by default), the upload gets `overflow: hidden` together with padding, so the cutting of the file remove button doesn't occur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/45)
<!-- Reviewable:end -->
