### PR TITLE
Remove the uploaded file fix

### DIFF
--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -650,6 +650,7 @@ Custom property | Description | Default
          if (file.xhr) {
            file.xhr.abort();
          }
+         this._notifyFileChanges(file);
        }
      },
 


### PR DESCRIPTION
Issue: when using the real backend, the remove button does nothing for uploaded file. The file element doesn't receive the abort notification due to the lack of file object change notification when setting `file.abort = true` in `vaadin-upload#_abortFileUpload` method.

This change adds the abort notification, hence fixes the remove button for uploaded files.

Unfortunately the issue is not testable with MockHttpRequest. The issue doesn't take place. Tried to add a test, but unable to make it fail without the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/46)
<!-- Reviewable:end -->
