### PR TITLE
Fix for file remove animation in Safari

### DIFF
--- a/vaadin-upload-file.html
+++ b/vaadin-upload-file.html
@@ -43,7 +43,7 @@ Custom property | Description | Default
       :host {
         @apply(--layout-vertical);
         margin: 8px 0;
-        padding: 8px 0 0;
+        padding: 6px 0 0;
         @apply(--vaadin-upload-file);
       }
 
@@ -149,16 +149,20 @@ Custom property | Description | Default
       }
 
       @keyframes fade-out {
+        0% {
+          max-height: 38px;
+        }
         50%  {
-          max-height: 50px;
+          max-height: 38px;
           margin: 8px 0;
-          padding: 8px 0 0;
+          padding: 6px 0 0;
+          opacity: 0;
         }
         100% {
-          opacity: 0;
           max-height: 0px;
           margin: 0;
           padding: 0;
+          opacity: 0;
         }
       }
     </style>


### PR DESCRIPTION
Issue: in Safari, when removing the file from the list, the animation had a jump in the beginning. Happened in both desktop and mobile Safari.

This commit fixes the jump in animation.

In addition, the file item padding top was slightly reduced to make the total height of the file match 4px grid declared by material design guidelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/49)
<!-- Reviewable:end -->
