### PR TITLE
Allow manual `xhr.send(...)` when the `upload-request` event is prevented

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -88,6 +88,22 @@ This program is available under Apache License Version 2.0, available at https:/
       </template>
     </demo-snippet>
 
+    <h3>Sending Files Without Wrapping in FormData</h3>
+    <demo-snippet>
+      <template>
+        <vaadin-upload id="rawDemo"></vaadin-upload>
+
+        <script>
+          var upload = document.querySelector('vaadin-upload#rawDemo');
+
+          upload.addEventListener('upload-request', function(event) {
+            event.preventDefault();
+            event.detail.xhr.send(event.detail.file);
+          });
+        </script>
+      </template>
+    </demo-snippet>
+
     <h3>Custom Reaction on Server Response</h3>
     <demo-snippet>
       <template>

--- a/demo/common.html
+++ b/demo/common.html
@@ -63,6 +63,9 @@
     var xhr = new MockHttpRequest();
     xhr.upload = {};
     xhr.onsend = function() {
+      if (xhr.upload.onloadstart) {
+        xhr.upload.onloadstart();
+      }
       var total = file && file.size || 1024, done = 0;
       function start() {
         setTimeout(progress, 1000);

--- a/docs/vaadin-upload-basic.adoc
+++ b/docs/vaadin-upload-basic.adoc
@@ -110,7 +110,7 @@ The following events are fired by the component in different phases of the uploa
 `upload-error`:: Fired if the upload process failed.
 `upload-progress`:: Fired as many times as a file progress is updated.
 `upload-request`:: Fired when the request has been opened but not yet sent. It is useful for appending additional data keys to the request and for changing some parameters such as headers.
-  If the event is default-prevented, then the request is not sent to the server.
+  If the event is default-prevented, then the request is not sent to the server. In this case, you can send the XHR manually.
 `upload-response`:: Fired when the server response was received, but before the component processes it. It is useful for making the upload fail depending on the response.
   If the event is default-prevented, the vaadin-upload skips the default flow, allowing the developer to do something on his own, such as retrying the upload.
 `upload-retry`:: Fired when the upload is retried. If the default is prevented, retry would not be performed.

--- a/docs/vaadin-upload-server.adoc
+++ b/docs/vaadin-upload-server.adoc
@@ -50,43 +50,54 @@ There are certain events to modify the XHR before sending it, or the `response` 
 
 `upload-before`:: At this point, the XHR has not been opened yet, but you can set the server URL by setting the [propertyname]#file.uploadTarget# attribute.
 You can also reject the file at this point by preventing the default action.
-
++
 [source,javascript]
 ----
-  uploader.addEventListener('upload-before', function(e) {
-    e.detail.file.uploadTarget =
-      'http://127.0.0.1:8080/upload/servlet.gupld?filename=' + e.detail.file.name;
-  });
+uploader.addEventListener('upload-before', function(e) {
+  e.detail.file.uploadTarget =
+    'http://127.0.0.1:8080/upload/servlet.gupld?filename=' + e.detail.file.name;
+});
 
-  uploader.addEventListener('upload-before', function(e) {
-    if (e.detail.file.size > 10240) {
-      e.detail.file.error = 'File too big.'
-    }
-  });
+uploader.addEventListener('upload-before', function(e) {
+  if (e.detail.file.size > 10240) {
+    e.detail.file.error = 'File too big.'
+  }
+});
 ----
 
-`upload-request`::
-You can change request parameters before it is sent, append data keys to the request, or cancel sending the request to the server by calling [methodname]#event.preventDefault()#.
-
+`upload-request`:: You can change the request headers before it is sent and append data keys to the request.
++
 [source,javascript]
 ----
-  uploader.addEventListener('upload-request', function(e) {
-    e.detail.xhr.setRequestHeader('Accept', 'application/json');
-    e.detail.formData.append('documentId', 1234);
-  });
+uploader.addEventListener('upload-request', function(e) {
+  e.detail.xhr.setRequestHeader('Accept', 'application/json');
+  e.detail.formData.append('documentId', 1234);
+});
+----
++
+You can cancel sending the request to the server by calling [methodname]#event.preventDefault()#.
+In this case, you can send the request manually.
+This allows you to upload the file directly in the request data instead of inside a FormData wrapper.
++
+[source,javascript]
+----
+uploader.addEventListener('upload-request', function(e) {
+  e.preventDefault();
+  e.detail.xhr.send(e.detail.file);
+});
 ----
 
 `upload-response`:: The event is dispatched when the server message was received, but before the component processes it.
-  At this point, you can check the response and make the upload fail by setting the [propertyname]#file.error# property.
-  If the event is default-prevented, the response is not checked for errors and the UI is not updated.
-
+At this point, you can check the response and make the upload fail by setting the [propertyname]#file.error# property.
+If the event is default-prevented, the response is not checked for errors and the UI is not updated.
++
 [source,javascript]
 ----
-  uploader.addEventListener('upload-response', function(e) {
-    if (e.detail.xhr.status == 200) {
-      e.detail.file.error = JSON.parse(xhr.responseText).error;
-    }
-  });
+uploader.addEventListener('upload-response', function(e) {
+  if (e.detail.xhr.status == 200) {
+    e.detail.file.error = JSON.parse(xhr.responseText).error;
+  }
+});
 ----
 
 == Server Processing

--- a/test/upload.html
+++ b/test/upload.html
@@ -154,16 +154,16 @@
           upload._uploadFile(file);
         });
 
-        it('should do nothing if a `upload-request` listener prevents default', function(done) {
+        it('should not send xhr if `upload-request` listener prevents default', function(done) {
           upload.addEventListener('upload-request', function(e) {
             e.preventDefault();
+
+            Polymer.Base.async(function() {
+              expect(e.detail.xhr.readyState).to.be.equal(1);
+              done();
+            }, 100);
           });
 
-          Polymer.Base.async(function() {
-            expect(file.uploading).not.to.be.ok;
-            expect(file.error).not.to.be.ok;
-            done();
-          }, 200);
           upload._uploadFile(file);
         });
 

--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -663,19 +663,21 @@ Custom property | Description | Default
       xhr.open(this.method, file.uploadTarget, true);
       this._configureXhr(xhr);
 
-      // Custom listener could modify the xhr just before sending it
-      // preventing default
-      evt = this.fire('upload-request', {file: file, xhr: xhr, formData: formData}, {cancelable: true});
-      if (evt.defaultPrevented) {
-        return;
-      }
-
       file.status = this.i18n.uploading.status.connecting;
       file.uploading = file.indeterminate = true;
       file.complete = file.abort = file.error = false;
-      this.fire('upload-start', {file: file, xhr: xhr});
-      this._notifyFileChanges(file);
-      xhr.send(formData);
+
+      xhr.upload.onloadstart = function() {
+        this.fire('upload-start', {file: file, xhr: xhr});
+        this._notifyFileChanges(file);
+      }.bind(this);
+
+      // Custom listener could modify the xhr just before sending it
+      // preventing default
+      evt = this.fire('upload-request', {file: file, xhr: xhr, formData: formData}, {cancelable: true});
+      if (!evt.defaultPrevented) {
+        xhr.send(formData);
+      }
     },
 
     _retryFileUpload: function(file) {


### PR DESCRIPTION
Resolves #96 without the API changes.

When the `upload-request` event is prevented, the `xhr.send(formData)` is not called in the upload. At the same time, a couple of state file properties are not updated in this case. Therefore, it's hard to send the xhr manually.

This PR allows developers to call `xhr.send(whatever)` manually in the `upload-request` event listener, while preventing the default send call. This also makes it possible to send files directly without a FormData wrapper, as well as allows custom data wrappers/encodings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/113)
<!-- Reviewable:end -->
