### PR TITLE
Try to fix build by replacing travis_retry with travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install: travis_retry npm install
 script:
   - gulp lint:js
   - gulp lint:html
-  - travis_retry gulp test:mobile
-  - travis_retry gulp test:desktop
-  - travis_retry gulp test:mobile:shadow
-  - travis_retry gulp test:desktop:shadow
+  - travis_wait gulp test:mobile
+  - travis_wait gulp test:desktop
+  - travis_wait gulp test:mobile:shadow
+  - travis_wait gulp test:desktop:shadow


### PR DESCRIPTION
Some of the recent builds are failed with this TravisCI error:

> No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.

This is the common issue described here: 

https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

I'm not 100% sure about removing `travis_retry`, but most probably it was attempt to fix the build so I replaced it with `travis_wait`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/129)
<!-- Reviewable:end -->
