### PR TITLE
Add multiple property to component

### DIFF
--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -161,7 +161,7 @@ Custom property | Description | Default
       </div>
     </content>
     <content></content>
-    <input type="file" id="fileInput" on-change="_onFileInputChange" hidden accept$="{{accept}}" multiple$="[[_isMultiple(maxFiles)]]">
+    <input type="file" id="fileInput" on-change="_onFileInputChange" hidden accept$="{{accept}}" multiple$="[[multiple]]">
     <paper-ripple id="dragRipple" noink></paper-ripple>
   </template>
 </dom-module>
@@ -318,6 +318,15 @@ Custom property | Description | Default
       formDataName: {
         type: String,
         value: 'file'
+      },
+      
+      /**
+       * Specifies if the input should be allowed to accept multiple
+       * files
+       */
+      multiple: {
+        type: Boolean,
+        value: false
       },
 
       /**
@@ -798,10 +807,6 @@ Custom property | Description | Default
 
     _i18nPlural: function(value, plural) {
       return value == 1 ? plural.one : plural.many;
-    },
-
-    _isMultiple: function() {
-      return this.maxFiles != 1;
     }
   });
 


### PR DESCRIPTION
Adding the `multiple` property gives better control to the consumer of the component for still allowing multiple files to be uploaded one at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/149)
<!-- Reviewable:end -->
