### PR TITLE
Fix refresh-button not hiding when upload was successful

### DIFF
--- a/vaadin-upload-file.html
+++ b/vaadin-upload-file.html
@@ -180,7 +180,7 @@ Custom property | Description | Default
       paper-progress[complete] {
         @apply(--vaadin-upload-file-progress-complete);
       }
-      
+
       paper-icon-button[hidden] {
         display: none;
       }

--- a/vaadin-upload-file.html
+++ b/vaadin-upload-file.html
@@ -180,6 +180,10 @@ Custom property | Description | Default
       paper-progress[complete] {
         @apply(--vaadin-upload-file-progress-complete);
       }
+      
+      paper-icon-button[hidden] {
+        display: none;
+      }
 
       :host(.fade-out) {
         animation-name: fade-out;
@@ -224,9 +228,7 @@ Custom property | Description | Default
       </div>
 
       <div id="commands">
-        <div hidden$="[[!file.error]]">
-          <paper-icon-button icon="vaadin-upload:refresh" file-event="file-retry" on-tap="_fireFileEvent"></paper-icon-button>
-        </div>
+        <paper-icon-button icon="vaadin-upload:refresh" file-event="file-retry" on-tap="_fireFileEvent" hidden$="[[!file.error]]"></paper-icon-button>
         <paper-icon-button icon="vaadin-upload:clear" file-event="file-abort" on-tap="_fireFileEvent"></paper-icon-button>
       </div>
 


### PR DESCRIPTION
## Refresh button not hiding when upload was successful
I do not have the reason for that yet, but I figured out that the refresh-button (paper-icon-button to re-upload the file) won't hide even if it should when the upload of that file was successful. (Why would you want to re-upload an already uploaded file?).

The hidden$ - Attribute on the paper-icon-button somehow doesn't seem to work for me, wrapping it in a &lt;div&gt; with the attribute on it, it will behave correctly (Show when an error appears, hide when the upload was successful)

---

```HTML
<div hidden$="[[!file.error]]">
  <paper-icon-button ... ></paper-icon-button>
</div>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/155)
<!-- Reviewable:end -->
