### PR TITLE
Accept wildcard replacement with regex not string.replace

### DIFF
--- a/test/adding-files.html
+++ b/test/adding-files.html
@@ -269,7 +269,7 @@
           upload.accept = 'text/*,application/*,image/*,video/*,audio/*';
           upload._addFiles([file]);
           expect(upload.files.length).to.equal(1);
-        })
+        });
       });
 
     });

--- a/test/adding-files.html
+++ b/test/adding-files.html
@@ -264,6 +264,12 @@
           upload._addFiles([file]);
           expect(upload.files.length).to.equal(1);
         });
+
+        it('should allow files matching other than the first wildcard', function () {
+          upload.accept = 'text/*,application/*,image/*,video/*,audio/*';
+          upload._addFiles([file]);
+          expect(upload.files.length).to.equal(1);
+        })
       });
 
     });

--- a/test/adding-files.html
+++ b/test/adding-files.html
@@ -265,7 +265,7 @@
           expect(upload.files.length).to.equal(1);
         });
 
-        it('should allow files matching other than the first wildcard', function () {
+        it('should allow files matching other than the first wildcard', function() {
           upload.accept = 'text/*,application/*,image/*,video/*,audio/*';
           upload._addFiles([file]);
           expect(upload.files.length).to.equal(1);

--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -738,7 +738,7 @@ Custom property | Description | Default
         return;
       }
       var fileExt = file.name.match(/\.[^\.]*$|$/)[0];
-      var re = new RegExp('^(' + this.accept.replace(/[, ]+/g, '|').replace('/*', '/.*') + ')$', 'i');
+      var re = new RegExp('^(' + this.accept.replace(/[, ]+/g, '|').replace(/\/\*/g, '/.*') + ')$', 'i');
       if (this.accept && !(re.test(file.type) || re.test(fileExt))) {
         this.fire('file-reject', {file: file, error: this.i18n.error.incorrectFileType});
         return;


### PR DESCRIPTION
When using multiple wildcards in the accept pattern, only the first one is replaced by string.replace.
When using a regex each wildcard will be read correctly.


# Example:
`accept="text/*, application/*, image/*, video/*, audio/*"`

## Resulting regex:
### before:
`/^(text\/.*|application\/*|image\/*|video\/*|audio\/*)$/i`

### after:
`/^(text\/.*|application\/.*|image\/.*|video\/.*|audio\/.*)$/i`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/159)
<!-- Reviewable:end -->
