### PR TITLE
New: Upload on-demand

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,24 +27,24 @@
     "package.json",
     "wct.conf.js"
   ],
-  "devDependencies": {
-    "web-component-tester": "^5.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "elements-demo-resources": "Vaadin/elements-demo-resources#master",
-    "mock-http-request": "philikon/MockHttpRequest#master",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "paper-toast": "PolymerElements/paper-toast#^1.0.0"
-  },
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.4",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-    "paper-ripple": "PolymerElements/paper-ripple#~1.0.0",
-    "paper-button": "PolymerElements/paper-button#^1.0.0",
-    "paper-progress": "PolymerElements/paper-progress#^1.0.0",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
-    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0"
+    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-progress": "PolymerElements/paper-progress#^1.0.0",
+    "paper-ripple": "PolymerElements/paper-ripple#~1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "polymer": "Polymer/polymer#^1.2.4"
+  },
+  "devDependencies": {
+    "elements-demo-resources": "Vaadin/elements-demo-resources#master",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+    "mock-http-request": "philikon/MockHttpRequest#master",
+    "paper-toast": "PolymerElements/paper-toast#^1.0.0",
+    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^5.0.0"
   }
 }

--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -178,6 +178,30 @@ This program is available under Apache License Version 2.0, available at https:/
         </dom-module>
       </template>
     </demo-snippet>
+
+    <h3>Manual Upload Trigger</h3>
+    <demo-snippet>
+      <template>
+        <vaadin-upload id="manualUpload" no-auto></vaadin-upload>
+        <br>
+        <button id="uploadButton">Start Upload(s)</button>
+
+        <script>
+          var upload5 = document.querySelector('vaadin-upload#manualUpload');
+          var uploadButton = document.getElementById('uploadButton');
+
+          uploadButton.addEventListener('click', function() {
+            upload5.uploadFiles();
+          });
+
+          // Change upload button text
+          upload5.set('i18n.addFiles', {
+            one: 'Add File',
+            many: 'Add Files'
+          });
+        </script>
+      </template>
+    </demo-snippet>
   </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "test": "wct"
   },
   "devDependencies": {
-    "eslint-plugin-html": "^1.7.0",
     "eslint-config-vaadin": "^0.1.0",
+    "eslint-plugin-html": "^1.7.0",
     "gulp": "latest",
-    "gulp-html-extract": "^0.0.3",
     "gulp-eslint": "^3.0.1",
+    "gulp-html-extract": "^0.0.3",
     "gulp-stylelint": "^3.7.0",
     "stylelint-config-vaadin": "^0.1.0",
     "web-component-tester": "^5.0.0"

--- a/test/adding-files.html
+++ b/test/adding-files.html
@@ -216,6 +216,14 @@
         files.forEach(upload._addFile.bind(upload));
         uploadStartSpy.should.have.been.calledTwice;
       });
+      it('should not automatically start upload when noAuto flag is set', function() {
+        var uploadStartSpy = sinon.spy();
+        upload.noAuto = true;
+        upload.addEventListener('upload-start', uploadStartSpy);
+
+        files.forEach(upload._addFile.bind(upload));
+        uploadStartSpy.should.not.have.been.called;
+      });
 
       describe('validate files', function() {
         it('should reject files when maxFiles is reached', function(done) {

--- a/test/upload.html
+++ b/test/upload.html
@@ -279,7 +279,7 @@
         it('should be indeterminate when connecting', function(done) {
           Polymer.Base.async(function() {
             expect(file.indeterminate).to.be.ok;
-            expect(file.status).to.be.equal('Connecting...');
+            expect(file.status).to.be.equal(upload.i18n.uploading.status.connecting);
             done();
           }, 200);
           upload._uploadFile(file);
@@ -317,10 +317,71 @@
 
         it('should be stalled when progress is not updated for more than 2 sec.', function(done) {
           Polymer.Base.async(function() {
-            expect(file.status).to.be.equal('Stalled.');
+            expect(file.status).to.be.equal(upload.i18n.uploading.status.stalled);
             done();
           }, 2200);
           upload._uploadFile(file);
+        });
+      });
+
+      describe('Manual Upload', function() {
+        var files;
+        beforeEach(function() {
+          upload.noAuto = true;
+          upload._createXhr = xhrCreator({size: file.size, uploadTime: 200, stepTime: 50});
+        });
+
+        it('should be in held status', function(done) {
+          upload._addFile(file);
+          flush(function() {
+            expect(file.uploaded).not.to.be.ok;
+            expect(file.status).to.be.equal(upload.i18n.uploading.status.held);
+            done();
+          });
+        });
+
+        it('should start uploading non-completed files after call to uploadFiles', function(done) {
+          var counter = 0;
+          files = createFiles(3, 512, 'application/json');
+          upload.files = files;
+          upload.files[1].complete = true;
+
+          for(var i = 0; i < upload.files.length; i++) {
+            expect(upload.files[i].uploading).not.to.be.ok;
+          }
+          upload.addEventListener('upload-start', function(e) {
+            expect(e.detail.xhr).to.be.ok;
+            expect(e.detail.file).to.be.ok;
+            expect(e.detail.file.uploading).to.be.ok;
+
+            if (++counter === (upload.files.length - 1)) {
+              done();
+            }
+          });
+          upload.uploadFiles();
+        });
+
+        it('should only start uploading files passed to uploadFiles call', function(done) {
+          var tempFileName = 'file-test';
+          files = createFiles(3, 512, 'application/json');
+          upload.files = files;
+          upload.files[2].name = tempFileName;
+
+          for(var i = 0; i < upload.files.length; i++) {
+            expect(upload.files[i].uploading).not.to.be.ok;
+          }
+          upload.addEventListener('upload-start', function(e) {
+            expect(e.detail.xhr).to.be.ok;
+            expect(e.detail.file).to.be.ok;
+            expect(e.detail.file.name).to.equal(tempFileName);
+            expect(e.detail.file.uploading).to.be.ok;
+
+            for(var i = 0; i < upload.files.length - 1; i++) {
+              expect(upload.files[i].uploading).not.to.be.ok;
+            }
+            done();
+          });
+          upload.uploadFiles([upload.files[2]]);
         });
       });
 

--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -343,6 +343,15 @@ Custom property | Description | Default
       },
 
       /**
+       * Prevents upload(s) from immediately uploading upon adding file(s).
+       * When set, you must manually trigger uploads using the `uploadFiles` method
+       */
+      noAuto: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * The object used to localize this component.
        * For changing the default localization, change the entire
        * _i18n_ object or just the property you want to modify.
@@ -368,7 +377,8 @@ Custom property | Description | Default
        status: {
          connecting: 'Connecting...',
          stalled: 'Stalled.',
-         processing: 'Processing File...'
+         processing: 'Processing File...',
+         held: 'Queued'
        },
        remainingTime: {
          prefix: 'remaining time: ',
@@ -416,7 +426,8 @@ Custom property | Description | Default
               status: {
                 connecting: 'Connecting...',
                 stalled: 'Stalled.',
-                processing: 'Processing File...'
+                processing: 'Processing File...',
+                held: 'Queued'
               },
               remainingTime: {
                 prefix: 'remaining time: ',
@@ -613,6 +624,19 @@ Custom property | Description | Default
       file.status = this._formatFileProgress(file);
     },
 
+    /**
+     * Triggers the upload of any files that are not completed
+     *
+     * @param {Array} [files] - Files being uploaded. Defaults to all outstanding files
+     */
+    uploadFiles: function(files) {
+      files = files || this.files;
+      files = files.filter(function(file) {
+        return !file.complete;
+      });
+      Array.prototype.forEach.call(files, this._uploadFile.bind(this));
+    },
+
     _uploadFile: function(file) {
       if (file.uploading) {
         return;
@@ -766,8 +790,12 @@ Custom property | Description | Default
         return;
       }
       file.loaded = 0;
+      file.status = this.i18n.uploading.status.held;
       this.unshift('files', file);
-      this._uploadFile(file);
+
+      if (!this.noAuto) {
+        this._uploadFile(file);
+      }
     },
 
     /**
@@ -833,8 +861,8 @@ Custom property | Description | Default
    *
    * @event file-reject
    * @param {Object} detail
-   *  @param {Object} detail.file the file added
-   *  @param {Object} detail.error the cause
+   * @param {Object} detail.file the file added
+   * @param {Object} detail.error the cause
    */
 
   /**
@@ -843,9 +871,9 @@ Custom property | Description | Default
    *
    * @event upload-before
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
-   *   @param {Object} detail.file.uploadTarget the upload request URL, initialized with the value of vaadin-upload `target` property
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.file.uploadTarget the upload request URL, initialized with the value of vaadin-upload `target` property
    */
 
   /**
@@ -856,9 +884,9 @@ Custom property | Description | Default
    *
    * @event upload-request
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
-   *  @param {Object} detail.formData the FormData object
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.formData the FormData object
    */
 
   /**
@@ -866,8 +894,8 @@ Custom property | Description | Default
    *
    * @event upload-start
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
    */
 
   /**
@@ -875,8 +903,8 @@ Custom property | Description | Default
    *
    * @event upload-progress
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded with loaded info
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded with loaded info
    */
 
   /**
@@ -891,8 +919,8 @@ Custom property | Description | Default
    *
    * @event upload-response
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
    */
 
   /**
@@ -900,8 +928,8 @@ Custom property | Description | Default
    *
    * @event upload-success
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded with loaded info
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded with loaded info
    */
 
   /**
@@ -909,8 +937,8 @@ Custom property | Description | Default
    *
    * @event upload-error
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
    */
 
   /**
@@ -919,8 +947,8 @@ Custom property | Description | Default
    *
    * @event upload-retry
    * @param {Object} detail
-   *  @param {Object} detail.xhr the previous upload xhr
-   *  @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.xhr the previous upload xhr
+   * @param {Object} detail.file the file being uploaded
    */
 
   /**
@@ -929,8 +957,8 @@ Custom property | Description | Default
    *
    * @event upload-abort
    * @param {Object} detail
-   *  @param {Object} detail.xhr the xhr
-   *  @param {Object} detail.file the file being uploaded
+   * @param {Object} detail.xhr the xhr
+   * @param {Object} detail.file the file being uploaded
    */
 
 </script>


### PR DESCRIPTION
This is just an initial approach to get your thoughts. I will test and document after it has been okayed from a approach perspective. This would solve #123 

Added 3 files
![image](https://cloud.githubusercontent.com/assets/855184/24807176/ddcc4e0e-1b7c-11e7-8a6a-9ca879877342.png)

Triggered Upload on 2 of the 3 (`this.$.upload.uploadFiles(this.files.slice(0,2))`)
![image](https://cloud.githubusercontent.com/assets/855184/24807236/10c165ba-1b7d-11e7-83ec-7f0de1f006c7.png)

**NOTE:** Decided on `auto` to function similarly to `iron-ajax` but please note that this would be a breaking-change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/168)
<!-- Reviewable:end -->