### PR TITLE
Fix: Revert slot to content

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -162,7 +162,7 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             </style>
             <vaadin-upload id="upload" max-files="1" max-files-reached="{{maxFilesReached}}">
-              <button slot="add-button" disabled$="[[maxFilesReached]]">
+              <button class="add-button" disabled$="[[maxFilesReached]]">
                 UPLOAD
               </button>
             </vaadin-upload>

--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -150,11 +150,11 @@ Custom property | Description | Default
     <div id="buttons">
       <div id="buttonsPrimary">
         <div id="addFiles" on-tap="_onAddFilesClick">
-          <slot name="add-button">
+          <content select=".add-button">
             <paper-button id="addButton" disabled$="[[maxFilesReached]]">
               [[_i18nPlural(maxFiles, i18n.addFiles, i18n.addFiles.*)]]
             </paper-button>
-          </slot>
+          </content>
         </div>
         <div id="dropLabel" hidden$="[[nodrop]]">
           <content select=".drop-label">


### PR DESCRIPTION
Addresses #170 

Needs to be merged before next release to prevent issues. 

Minimum Polymer version to use `slot` is 1.7.0.

`content` will need to be switched to `slot` in the `2.0-preview` branch/PR (#166)

@manolo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/171)
<!-- Reviewable:end -->
