### PR TITLE
Allowing changing the filename asynchronously, and only supplying one…

### DIFF
--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -632,7 +632,8 @@ Custom property | Description | Default
      * @param {Array} [files] - Files being uploaded. Defaults to all outstanding files
      */
     uploadFiles: function(files) {
-      files = files || this.files;
+      // if files is not an array, put it in an array
+      files = (typeof files === Array)?(files || this.files):[files];
       files = files.filter(function(file) {
         return !file.complete;
       });
@@ -712,7 +713,7 @@ Custom property | Description | Default
 
       var formData = new FormData();
 
-      file.uploadTarget = this.target || '';
+      file.uploadTarget = file.uploadTarget || this.target || '';
       file.formDataName = this.formDataName;
       var evt = this.fire('upload-before', {file: file, xhr: xhr}, {cancelable: true});
       if (evt.defaultPrevented) {


### PR DESCRIPTION
My use-case requires asynchronous computation of a new filename (done on a server), so I used the upload-before event with defaultPrevent=true, and when the computation is completed I set file.uploadTarget and call uploadFiles(file).

To this end, I needed to stop _uploadFile() from overwriting it with this.target or '', if it was already set.

I also found it tiresome to have to wrap my single file in an array so change uploadFiles() to accept a single file and it wrapped it in the array (though perhaps there is a tidier way