### PR TITLE
Set Chrome version to 58 for Selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: node_js
 node_js: stable
@@ -10,6 +10,12 @@ cache:
 addons:
   firefox: latest
   google-chrome: latest
+
+# Temporary fix, currently there are some weird timeout issues in Travis with Chrome 59
+# TODO @limonte revisit after Chrome 60 release
+before_install:
+  - wget http://mirror.glendaleacademy.org/chrome/pool/main/g/google-chrome-stable/google-chrome-stable_58.0.3029.110-1_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
 
 install:
   - npm install


### PR DESCRIPTION
Currently build if failing on master because of Chrome 59 upgrade. 

Let's fix Chrome version to 58 and revisit the issue after Chrome 60 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/202)
<!-- Reviewable:end -->
