### PR TITLE
Fix bower dependency issue for 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "wct.conf.js"
   ],
   "dependencies": {
-    "polymer": "^2.0.0",
+    "polymer": "1.7 - 2.0.0",
     "iron-icon": "^2.0.0",
     "iron-iconset-svg": "^2.0.0",
     "paper-button": "^2.0.0",


### PR DESCRIPTION
Since this is a hybrid element it should not hard require polymer 2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/207)
<!-- Reviewable:end -->
