### PR TITLE
Fix: Bower variants

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,68 +28,55 @@
     "wct.conf.js"
   ],
   "dependencies": {
-    "polymer": "^2.0.0",
-    "iron-icon": "^2.0.0",
-    "iron-iconset-svg": "^2.0.0",
-    "paper-button": "^2.0.0",
-    "paper-icon-button": "^2.0.0",
-    "paper-progress": "^2.0.0",
-    "paper-ripple": "PolymerElements/paper-ripple#^2.0.0",
-    "paper-styles": "^2.0.0"
+    "polymer": "Polymer/polymer#1.9 - 2",
+    "iron-icon": "PolymerElements/iron-icon#1 - 2",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#1 - 2",
+    "paper-button": "PolymerElements/paper-button#1 - 2",
+    "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
+    "paper-progress": "PolymerElements/paper-progress#1 - 2",
+    "paper-ripple": "PolymerElements/paper-ripple#1 - 2",
+    "paper-styles": "PolymerElements/paper-styles#1 - 2"
   },
   "devDependencies": {
     "elements-demo-resources": "vaadin/elements-demo-resources#^2.0.0",
-    "iron-component-page": "^2.0.0",
-    "iron-demo-helpers": "^2.0.0",
-    "iron-test-helpers": "^2.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
     "mock-http-request": "philikon/MockHttpRequest#master",
-    "paper-toast": "^2.0.0",
-    "test-fixture": "^3.0.0",
-    "web-component-tester": "^6.0.0"
+    "paper-toast": "PolymerElements/paper-toast#1 - 2",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
-        "polymer": "^1.7.0"
+        "polymer": "Polymer/polymer#^1.9",
+        "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+        "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+        "paper-button": "PolymerElements/paper-button#^1.0.0",
+        "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+        "paper-progress": "PolymerElements/paper-progress#^1.0.0",
+        "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.1.4"
       },
       "devDependencies": {
-        "web-component-tester": "^6.0.0"
+        "elements-demo-resources": "vaadin/elements-demo-resources#^2.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "mock-http-request": "philikon/MockHttpRequest#master",
+        "paper-toast": "PolymerElements/paper-toast#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "web-component-tester": "Polymer/web-component-tester#^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },
       "resolutions": {
-        "polymer": "^1.7.0",
-        "webcomponentsjs": "^0.7.24"
+        "webcomponentsjs": "^0.7"
       }
     }
   },
   "resolutions": {
-    "iron-flex-layout": "1 - 2",
-    "iron-meta": "1 - 2",
-    "paper-behaviors": "1 - 2",
-    "iron-behaviors": "1 - 2",
-    "iron-a11y-keys-behavior": "1 - 2",
-    "iron-checked-element-behavior": "1 - 2",
-    "iron-validatable-behavior": "1 - 2",
-    "iron-form-element-behavior": "1 - 2",
-    "paper-ripple": "1 - 2",
-    "paper-styles": "1 - 2",
-    "iron-icon": "1 - 2",
-    "iron-range-behavior": "1 - 2",
-    "iron-demo-helpers": "^2.0.0",
-    "iron-location": "1 - 2",
-    "iron-doc-viewer": "^2.0.0",
-    "paper-button": "1 - 2",
-    "iron-ajax": "^2.0.0",
-    "marked-element": "1 - 2",
-    "prism-element": "1 - 2",
-    "app-layout": "1 - 2",
-    "iron-media-query": "1 - 2",
-    "iron-resizable-behavior": "1 - 2",
-    "iron-scroll-target-behavior": "1 - 2",
-    "iron-icons": "1 - 2",
-    "iron-iconset-svg": "1 - 2",
-    "iron-selector": "1 - 2",
-    "iron-a11y-announcer": "1 - 2",
-    "iron-overlay-behavior": "1 - 2",
-    "iron-fit-behavior": "1 - 2"
+    "webcomponentsjs": "^1.0"
   }
 }


### PR DESCRIPTION
Fixes #208 and Closes #207 

The current bower "variant" setup doesn't play nicely with the Polymer team's variant resolution process. This causes potentially tons of dependencies to have to be manually resolved.

The solution is moving towards the standard bower variants setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/209)
<!-- Reviewable:end -->
