### PR TITLE
Use a fork of MockHttpRequest which has a valid package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -66,7 +66,7 @@
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-        "mock-http-request": "philikon/MockHttpRequest#master",
+        "mock-http-request": "abuinitski/MockHttpRequest#npm_fix",
         "paper-toast": "PolymerElements/paper-toast#^1.0.0",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "Polymer/web-component-tester#^4.0.0",


### PR DESCRIPTION
The original MockHttpRequest repository (last updated 7 years ago) has an
invalid package.json which causes issues with at least some build tools which
try to read it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/212)
<!-- Reviewable:end -->
