### PR TITLE
Fix: IE11 Flex Regression

### DIFF
--- a/vaadin-upload.html
+++ b/vaadin-upload.html
@@ -57,7 +57,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       [part="drop-label"] {
         display: flex;
-        flex: 1;
+        flex: 1 1 auto;
       }
 
       [part="drop-label-icon"] {


### PR DESCRIPTION
IE11 requires a explicit flex basis defined when using the `flex` property. This was introduced in #211 and Fixes #225 

This is the outcome of my change when manually testing in IE11 through BrowserStack.
![pasted image at 2017_11_10 01_13 pm](https://user-images.githubusercontent.com/855184/32674630-9d20e944-c619-11e7-9a19-d81c61be1532.png)

@manolo Thanks for pointing it out!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/226)
<!-- Reviewable:end -->
