### PR TITLE
Force display: none for the hidden div

### DIFF
--- a/src/vaadin-upload.html
+++ b/src/vaadin-upload.html
@@ -24,8 +24,8 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none !important;
       }
 
-      div[hidden] {
-        display: none;
+      [hidden] {
+        display: none !important;
       }
     </style>
 

--- a/test/adding-files.html
+++ b/test/adding-files.html
@@ -9,7 +9,6 @@
   <script src="common.js"></script>
 
   <link rel="import" href="common.html">
-  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 </head>
 
 <body>

--- a/test/file-list.html
+++ b/test/file-list.html
@@ -8,7 +8,6 @@
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="common.html">
-  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 </head>
 
 <body>


### PR DESCRIPTION
The `iron-flex-layout.html` import in tests does the weird thing by setting the `display: none !important` on the `[hidden]` elements, see the trick [here](https://github.com/PolymerElements/iron-flex-layout/blob/master/iron-flex-layout.html#L66) 

When removing the import, it appears that the ShadyCSS rewrites the selector in the theme:
```css
[part="primary-buttons"] > * {
  display: inline-block;
  white-space: nowrap;
}
```
so it looks like this:

```css
[part="primary-buttons"].vaadin-upload > *.vaadin-upload {
  display: inline-block;
  white-space: nowrap;
}
```

So the [test](https://github.com/vaadin/vaadin-upload/blob/master/test/adding-files.html#L211) is false-positive when using ShadyDOM, and since we probably do not want to play with specificity, let's just use `!important` as we already do in the above rule for the host element itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/260)
<!-- Reviewable:end -->
