### PR TITLE
Reorganize demo structure

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,25 +2,47 @@
   "name": "Vaadin Upload",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Basics",
     "url": "upload-basic-demos",
     "src": "upload-basic-demos.html",
     "meta": {
       "title": "vaadin-upload Basic Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Advanced Usage",
-    "url": "upload-advanced-demos",
-    "src": "upload-advanced-demos.html",
+    "name": "Limit Files",
+    "url": "upload-limit-files-demos",
+    "src": "upload-limit-files-demos.html",
     "meta": {
-      "title": "vaadin-upload Advanced Examples",
+      "title": "vaadin-upload Limit Files Examples",
       "description": "",
       "image": ""
-     }
+    }
+  }
+  ,
+  {
+    "name": "Customize Upload Events",
+    "url": "upload-customize-upload-events-demos",
+    "src": "upload-customize-upload-events-demos.html",
+    "meta": {
+      "title": "vaadin-upload Customize Upload Events Examples",
+      "description": "",
+      "image": ""
+    }
+  }
+  ,
+  {
+    "name": "Styling",
+    "url": "upload-styling-demos",
+    "src": "upload-styling-demos.html",
+    "meta": {
+      "title": "vaadin-upload Styling Examples",
+      "description": "",
+      "image": ""
+    }
   }
   ,
   {
@@ -31,7 +53,7 @@
       "title": "vaadin-upload I18n Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ]
 }

--- a/demo/upload-basic-demos.html
+++ b/demo/upload-basic-demos.html
@@ -15,71 +15,42 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Upload Request Properties</h3>
-    <vaadin-demo-snippet id='upload-basic-demos-upload-request-properties'>
+    <h3>Disable Drag & Drop</h3>
+    <vaadin-demo-snippet id='upload-basic-demos-disable-drag-n-drop'>
       <template preserve-content>
-        <vaadin-upload
-            target="serverUrl"
-            method="POST"
-            timeout="300000"
-            headers="{'X-Custom-Header': 'value'}"
-            form-data-name="my-attachment">
-        </vaadin-upload>
+        <vaadin-upload nodrop></vaadin-upload>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>Disabling Drag & Drop and Picking Multiple Files in the File Dialog</h3>
-    <vaadin-demo-snippet id='upload-basic-demos-disabling-drag--drop-and-picking-multiple-files-in-the-file-dialog'>
-      <template preserve-content>
-        <vaadin-upload nodrop max-files="1"></vaadin-upload>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Custom Drop Label</h3>
-    <vaadin-demo-snippet id='upload-basic-demos-custom-drop-label'>
-      <template preserve-content>
-        <vaadin-upload>
-          <iron-icon slot="drop-label-icon" icon="cloud-upload"></iron-icon>
-          <span slot="drop-label">Drop files to the cloud...</span>
-        </vaadin-upload>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Single File Upload</h3>
-    <vaadin-demo-snippet id='upload-basic-demos-single-file-upload'>
-      <template preserve-content>
-        <vaadin-upload max-files="1"></vaadin-upload>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Setting Restrictions on Files to Upload</h3>
-    <vaadin-demo-snippet id='upload-basic-demos-setting-restrictions-on-files-to-upload'>
-      <template preserve-content>
-        <vaadin-upload id="rejectEventDemo" max-files="3" accept="application/pdf" max-file-size="1000000">
-          <span slot="drop-label">Up to 3 PDF files, 1 MB each</span>
-        </vaadin-upload>
-
-        <script>
-          window.addDemoReadyListener('#upload-basic-demos-setting-restrictions-on-files-to-upload', function(document) {
-            var upload = document.querySelector('vaadin-upload#rejectEventDemo');
-
-            upload.addEventListener('file-reject', function(event) {
-              window.alert(event.detail.file.name + ' error: ' + event.detail.error);
-            });
-          });
-        </script>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Upload Capture Usage</h3>
+    <h3>Open Device Camera Directly</h3>
+    <p>Use the <code>capture</code> attribute to use native device features if available.</p>
     <vaadin-demo-snippet id='upload-basic-demos-capture-usage'>
       <template preserve-content>
         <vaadin-upload capture="camera" accept="image/*"></vaadin-upload>
       </template>
     </vaadin-demo-snippet>
+
+    <h3>Pre-Fill the File List</h3>
+    <vaadin-demo-snippet id='upload-basic-demos-pre-fill-the-file-list'>
+      <template preserve-content>
+        <vaadin-upload id="preFill" accept="application/pdf">
+          <iron-icon slot="drop-label-icon" icon="description"></iron-icon>
+          <span slot="drop-label">Drop your favourite Novels here</span>
+        </vaadin-upload>
+        <script>
+          window.addDemoReadyListener('#upload-basic-demos-pre-fill-the-file-list', function(document) {
+            var upload = document.querySelector('vaadin-upload#preFill');
+            upload.files = [
+              {name: 'Don Quixote.pdf', progress: 100, complete: true},
+              {name: 'Hamlet.pdf', progress: 100, complete: true}
+            ];
+            upload.set('i18n.addFiles.many', 'Select Books...');
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
 
   </template>
   <script>

--- a/demo/upload-customize-upload-events-demos.html
+++ b/demo/upload-customize-upload-events-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="upload-advanced-demos">
+<dom-module id="upload-customize-upload-events-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -7,37 +7,13 @@
     </style>
 
 
-    <h3>Custom File List</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-custom-file-list'>
-      <template preserve-content>
-        <dom-bind>
-          <template is="dom-bind">
-            <vaadin-upload id="fileEventsDemo" files="{{files}}">
-              <div slot="file-list">
-                <h4>Files</h4>
-                <ul>
-                  <template is="dom-repeat" items="{{files}}" as="file">
-                    <li>
-                      <strong>[[file.name]]</strong>
-                      [[file.status]]
-                    </li>
-                  </template>
-                </ul>
-              </div>
-            </vaadin-upload>
-          </template>
-        </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Customizing the Upload Request</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-customizing-the-upload-request'>
+    <vaadin-demo-snippet id='upload-customize-upload-events-demos-customizing-the-upload-request'>
       <template preserve-content>
         <vaadin-upload id="requestDemo"></vaadin-upload>
 
         <script>
-          window.addDemoReadyListener('#upload-advanced-demos-customizing-the-upload-request', function(document) {
+          window.addDemoReadyListener('#upload-customize-upload-events-demos-customizing-the-upload-request', function(document) {
             var upload = document.querySelector('vaadin-upload#requestDemo');
 
             upload.addEventListener('upload-before', function(event) {
@@ -72,12 +48,12 @@
 
 
     <h3>Sending Files Without Wrapping in FormData</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-sending-files-without-wrapping-in-formdata'>
+    <vaadin-demo-snippet id='upload-customize-upload-events-demos-sending-files-without-wrapping-in-formdata'>
       <template preserve-content>
         <vaadin-upload id="rawDemo"></vaadin-upload>
 
         <script>
-          window.addDemoReadyListener('#upload-advanced-demos-sending-files-without-wrapping-in-formdata', function(document) {
+          window.addDemoReadyListener('#upload-customize-upload-events-demos-sending-files-without-wrapping-in-formdata', function(document) {
             var upload = document.querySelector('vaadin-upload#rawDemo');
 
             upload.addEventListener('upload-request', function(event) {
@@ -91,12 +67,12 @@
 
 
     <h3>Custom Reaction on Server Response</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-custom-reaction-on-server-response'>
+    <vaadin-demo-snippet id='upload-customize-upload-events-demos-custom-reaction-on-server-response'>
       <template preserve-content>
         <vaadin-upload id="responseDemo"></vaadin-upload>
 
         <script>
-          window.addDemoReadyListener('#upload-advanced-demos-custom-reaction-on-server-response', function(document) {
+          window.addDemoReadyListener('#upload-customize-upload-events-demos-custom-reaction-on-server-response', function(document) {
             var upload = document.querySelector('vaadin-upload#responseDemo');
 
             upload.addEventListener('upload-response', function(event) {
@@ -112,48 +88,15 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Pre-Filling the File List in Advance</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-pre-filling-the-file-list-in-advance'>
-      <template preserve-content>
-        <vaadin-upload id="preFill" accept="application/pdf">
-          <iron-icon slot="drop-label-icon" icon="description"></iron-icon>
-          <span slot="drop-label">Drop your favourite Novels here</span>
-        </vaadin-upload>
-        <script>
-          window.addDemoReadyListener('#upload-advanced-demos-pre-filling-the-file-list-in-advance', function(document) {
-            var upload = document.querySelector('vaadin-upload#preFill');
-            upload.files = [
-              {name: 'Don Quixote.pdf', progress: 100, complete: true},
-              {name: 'Hamlet.pdf', progress: 100, complete: true}
-            ];
-            upload.set('i18n.addFiles.many', 'Select Books...');
-          });
-        </script>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Custom Upload Button</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-custom-upload-button'>
-      <template preserve-content>
-        <vaadin-upload id="upload">
-          <button slot="add-button">
-            Add Files...
-          </button>
-        </vaadin-upload>
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Manual Upload Trigger</h3>
-    <vaadin-demo-snippet id='upload-advanced-demos-manual-upload-trigger'>
+    <vaadin-demo-snippet id='upload-customize-upload-events-demos-manual-upload-trigger'>
       <template preserve-content>
         <vaadin-upload id="manualUpload" no-auto></vaadin-upload>
         <br>
         <button id="uploadButton">Start Upload(s)</button>
 
         <script>
-          window.addDemoReadyListener('#upload-advanced-demos-manual-upload-trigger', function(document) {
+          window.addDemoReadyListener('#upload-customize-upload-events-demos-manual-upload-trigger', function(document) {
             var upload = document.querySelector('vaadin-upload#manualUpload');
             var uploadButton = document.getElementById('uploadButton');
 
@@ -173,11 +116,11 @@
 
   </template>
   <script>
-    class UploadAdvancedDemos extends DemoReadyEventEmitter(UploadDemo(Polymer.Element)) {
+    class UploadCustomizeUploadEventsDemos extends DemoReadyEventEmitter(UploadDemo(Polymer.Element)) {
       static get is() {
-        return 'upload-advanced-demos';
+        return 'upload-customize-upload-events-demos';
       }
     }
-    customElements.define(UploadAdvancedDemos.is, UploadAdvancedDemos);
+    customElements.define(UploadCustomizeUploadEventsDemos.is, UploadCustomizeUploadEventsDemos);
   </script>
 </dom-module>

--- a/demo/upload-limit-files-demos.html
+++ b/demo/upload-limit-files-demos.html
@@ -1,0 +1,46 @@
+<dom-module id="upload-limit-files-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Limit File Count</h3>
+    <vaadin-demo-snippet id='upload-limit-files-demos-file-count'>
+      <template preserve-content>
+        <vaadin-upload max-files="1"></vaadin-upload>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Setting Restrictions on Files to Upload</h3>
+    <vaadin-demo-snippet id='upload-limit-files-demos-setting-restrictions-on-files-to-upload'>
+      <template preserve-content>
+        <vaadin-upload id="rejectEventDemo" max-files="3" accept="application/pdf" max-file-size="1000000">
+          <span slot="drop-label">Up to 3 PDF files, 1 MB each</span>
+        </vaadin-upload>
+
+        <script>
+          window.addDemoReadyListener('#upload-limit-files-demos-setting-restrictions-on-files-to-upload', function(document) {
+            var upload = document.querySelector('vaadin-upload#rejectEventDemo');
+
+            upload.addEventListener('file-reject', function(event) {
+              window.alert(event.detail.file.name + ' error: ' + event.detail.error);
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    
+  </template>
+  <script>
+    class UploadLimitFilesDemos extends DemoReadyEventEmitter(UploadDemo(Polymer.Element)) {
+      static get is() {
+        return 'upload-limit-files-demos';
+      }
+    }
+    customElements.define(UploadLimitFilesDemos.is, UploadLimitFilesDemos);
+  </script>
+</dom-module>

--- a/demo/upload-styling-demos.html
+++ b/demo/upload-styling-demos.html
@@ -1,0 +1,66 @@
+<dom-module id="upload-styling-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Custom Upload Button</h3>
+    <vaadin-demo-snippet id='upload-styling-demos-custom-upload-button'>
+      <template preserve-content>
+        <vaadin-upload id="upload">
+          <button slot="add-button">
+            Add Files...
+          </button>
+        </vaadin-upload>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Custom Drop Label</h3>
+    <vaadin-demo-snippet id='upload-styling-demos-custom-drop-label'>
+      <template preserve-content>
+        <vaadin-upload>
+          <iron-icon slot="drop-label-icon" icon="cloud-upload"></iron-icon>
+          <span slot="drop-label">Drop files to the cloud...</span>
+        </vaadin-upload>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Custom File List</h3>
+    <vaadin-demo-snippet id='upload-styling-demos-custom-file-list'>
+      <template preserve-content>
+        <dom-bind>
+          <template is="dom-bind">
+            <vaadin-upload id="fileEventsDemo" files="{{files}}">
+              <div slot="file-list">
+                <h4>Files</h4>
+                <ul>
+                  <template is="dom-repeat" items="{{files}}" as="file">
+                    <li>
+                      <strong>[[file.name]]</strong>
+                      [[file.status]]
+                    </li>
+                  </template>
+                </ul>
+              </div>
+            </vaadin-upload>
+          </template>
+        </dom-bind>
+      </template>
+    </vaadin-demo-snippet>
+
+    
+  </template>
+  <script>
+    class UploadStylingDemos extends DemoReadyEventEmitter(UploadDemo(Polymer.Element)) {
+      static get is() {
+        return 'upload-styling-demos';
+      }
+    }
+    customElements.define(UploadStylingDemos.is, UploadStylingDemos);
+  </script>
+</dom-module>


### PR DESCRIPTION
Connects to "Guidelines for component examples"
- Renamed Basic Examples -> Basics
- Created "Limit Files" demo page with examples
- Created "Customize Upload Events" demo page with examples
- Created "Styling" demo page with examples
- Removed "Upload Request Properties" example. Only shows API and not a use case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/274)
<!-- Reviewable:end -->
