### PR TITLE
Allowing setting the uploadTarget and passing single file to uploadFiles

### DIFF
--- a/src/vaadin-upload.html
+++ b/src/vaadin-upload.html
@@ -515,6 +515,9 @@ This program is available under Apache License Version 2.0, available at https:/
          * @param {Array} [files] - Files being uploaded. Defaults to all outstanding files
          */
         uploadFiles(files) {
+          if (files && !Array.isArray(files)) {
+            files = [files];
+          }
           files = files || this.files;
           files = files.filter(file => (!file.complete));
           Array.prototype.forEach.call(files, this._uploadFile.bind(this));
@@ -602,7 +605,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           const formData = new FormData();
 
-          file.uploadTarget = this.target || '';
+          file.uploadTarget = file.uploadTarget || this.target || '';
           file.formDataName = this.formDataName;
 
           const evt = this.dispatchEvent(

--- a/test/upload.html
+++ b/test/upload.html
@@ -166,6 +166,17 @@
           upload._uploadFile(file);
         });
 
+        it('should not override configurable request url if already set', done => {
+          const modifiedUrl = 'http://example.com/modified/url';
+          upload.addEventListener('upload-before', e => {
+            e.preventDefault();
+            expect(e.detail.file.uploadTarget).to.equal(modifiedUrl);
+            done();
+          });
+          file.uploadTarget = modifiedUrl;
+          upload._uploadFile(file);
+        });
+
         it('should fire the upload-before with configurable form data name', done => {
           function MockFormData() {
             this.data = [];
@@ -443,6 +454,22 @@
             done();
           });
           upload.uploadFiles([upload.files[2]]);
+        });
+
+        it('should start uploading a single file passed to uploadFiles call', done => {
+          const tempFileName = 'file-test';
+          files = createFiles(1, 512, 'application/json');
+          upload.files = files;
+          upload.files[0].name = tempFileName;
+
+          upload.addEventListener('upload-start', e => {
+            expect(e.detail.xhr).to.be.ok;
+            expect(e.detail.file).to.be.ok;
+            expect(e.detail.file.name).to.equal(tempFileName);
+            expect(e.detail.file.uploading).to.be.ok;
+            done();
+          });
+          upload.uploadFiles(upload.files[0]);
         });
 
         it('should start a file upload from the file-start event', done => {


### PR DESCRIPTION
Originally submitted in #181 by @davidmaxwaterman 

Note: looks like this would require a minor version bump.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload/293)
<!-- Reviewable:end -->
