### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -67,12 +67,12 @@ export type UploadFileReject = CustomEvent<{ file: UploadFile; error: string }>;
 /**
  * Fired when the `files` property changes.
  */
-export type UploadFilesChanged = CustomEvent<{ value: UploadFile[]; path: 'files' }>;
+export type UploadFilesChanged = CustomEvent<{ value: UploadFile[] }>;
 
 /**
  * Fired when the `max-files-reached` property changes.
  */
-export type UploadMaxFilesReachedChanged = CustomEvent<{ value: boolean; path: 'max-files-reached' }>;
+export type UploadMaxFilesReachedChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired before the XHR is opened. Could be used for changing the request
@@ -91,7 +91,7 @@ export type UploadStart = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>
 export type UploadProgress = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
- * Fired in case the upload process succeed.
+ * Fired in case the upload process succeeded.
  */
 export type UploadSuccess = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
@@ -119,7 +119,7 @@ export type UploadResponse = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile
 export type UploadRetry = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
- * Fired when retry abort is requested. If the default is prevented, then the
+ * Fired when upload abort is requested. If the default is prevented, then the
  * file upload would not be aborted.
  */
 export type UploadAbort = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;

--- a/src/vaadin-upload.d.ts
+++ b/src/vaadin-upload.d.ts
@@ -34,6 +34,19 @@ import { UploadEventMap, UploadFile, UploadI18n, UploadMethod } from './interfac
  * `dragover-valid` | A dragged file is valid with `maxFiles` and `accept` criteria | `:host`
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ *
+ * @fires {CustomEvent} file-reject - Fired when a file cannot be added to the queue due to a constrain.
+ * @fires {CustomEvent} files-changed - Fired when the `files` property changes.
+ * @fires {CustomEvent} max-files-reached-changed - Fired when the `maxFilesReached` property changes.
+ * @fires {CustomEvent} upload-before - Fired before the XHR is opened.
+ * @fires {CustomEvent} upload-start - Fired when the XHR is sent.
+ * @fires {CustomEvent} upload-progress - Fired as many times as the progress is updated.
+ * @fires {CustomEvent} upload-success - Fired in case the upload process succeeded.
+ * @fires {CustomEvent} upload-error - Fired in case the upload process failed.
+ * @fires {CustomEvent} upload-request - Fired when the XHR has been opened but not sent yet.
+ * @fires {CustomEvent} upload-response - Fired when on the server response before analyzing it.
+ * @fires {CustomEvent} upload-retry - Fired when retry upload is requested.
+ * @fires {CustomEvent} upload-abort - Fired when upload abort is requested.
  */
 declare class UploadElement extends ThemableMixin(ElementMixin(HTMLElement)) {
   /**

--- a/src/vaadin-upload.js
+++ b/src/vaadin-upload.js
@@ -43,6 +43,19 @@ import './vaadin-upload-file.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {CustomEvent} file-reject - Fired when a file cannot be added to the queue due to a constrain.
+ * @fires {CustomEvent} files-changed - Fired when the `files` property changes.
+ * @fires {CustomEvent} max-files-reached-changed - Fired when the `maxFilesReached` property changes.
+ * @fires {CustomEvent} upload-before - Fired before the XHR is opened.
+ * @fires {CustomEvent} upload-start - Fired when the XHR is sent.
+ * @fires {CustomEvent} upload-progress - Fired as many times as the progress is updated.
+ * @fires {CustomEvent} upload-success - Fired in case the upload process succeeded.
+ * @fires {CustomEvent} upload-error - Fired in case the upload process failed.
+ * @fires {CustomEvent} upload-request - Fired when the XHR has been opened but not sent yet.
+ * @fires {CustomEvent} upload-response - Fired when on the server response before analyzing it.
+ * @fires {CustomEvent} upload-retry - Fired when retry upload is requested.
+ * @fires {CustomEvent} upload-abort - Fired when upload abort is requested.
+ *
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Removed `path` from events typings as Polymer-specific and generally unused.